### PR TITLE
Support UseSystemPasswordChar and PasswordChar on MaterialSingleLineTextField

### DIFF
--- a/MaterialSkin/Controls/MaterialSingleLineTextField.cs
+++ b/MaterialSkin/Controls/MaterialSingleLineTextField.cs
@@ -1050,7 +1050,7 @@ namespace MaterialSkin.Controls
                 {
                     if (value)
                     {
-                        useSystemPasswordChar = Application.RenderWithVisualStyles ? VisualStylePasswordChar : NonVisualStylePasswordChar; ;
+                        useSystemPasswordChar = Application.RenderWithVisualStyles ? VisualStylePasswordChar : NonVisualStylePasswordChar;
                     }
                     else
                     {

--- a/MaterialSkin/Controls/MaterialSingleLineTextField.cs
+++ b/MaterialSkin/Controls/MaterialSingleLineTextField.cs
@@ -21,6 +21,9 @@ namespace MaterialSkin.Controls
         public override string Text { get { return baseTextBox.Text; } set { baseTextBox.Text = value; } }
         public string Hint { get { return baseTextBox.Hint; } set { baseTextBox.Hint = value; } }
 
+        public bool UseSystemPasswordChar { get { return baseTextBox.UseSystemPasswordChar; } set { baseTextBox.UseSystemPasswordChar = value; } }
+        public char PasswordChar { get { return baseTextBox.PasswordChar; } set { baseTextBox.PasswordChar = value; } }
+
         # region Forwarding events to baseTextBox
         public event EventHandler AcceptsTabChanged
         {
@@ -1013,6 +1016,9 @@ namespace MaterialSkin.Controls
             private static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
 
             private const int EM_SETCUEBANNER = 0x1501;
+            private const char EmptyChar = (char)0;
+            private const char VisualStylePasswordChar = '\u25CF';
+            private const char NonVisualStylePasswordChar = '\u002A';
 
             private string hint = string.Empty;
             public string Hint
@@ -1023,6 +1029,41 @@ namespace MaterialSkin.Controls
                     hint = value;
                     SendMessage(Handle, EM_SETCUEBANNER, (int)IntPtr.Zero, Hint);
                 }
+            }
+
+            private char passwordChar = EmptyChar;
+            public new char PasswordChar
+            {
+                get { return passwordChar; }
+                set
+                {
+                    passwordChar = value;
+                    SetBasePasswordChar();
+                }
+            }
+
+            private char useSystemPasswordChar = EmptyChar;
+            public new bool UseSystemPasswordChar
+            {
+                get { return useSystemPasswordChar != EmptyChar; }
+                set
+                {
+                    if (value)
+                    {
+                        useSystemPasswordChar = Application.RenderWithVisualStyles ? VisualStylePasswordChar : NonVisualStylePasswordChar; ;
+                    }
+                    else
+                    {
+                        useSystemPasswordChar = EmptyChar;
+                    }
+
+                    SetBasePasswordChar();
+                }
+            }
+
+            private void SetBasePasswordChar()
+            {
+                base.PasswordChar = UseSystemPasswordChar ? useSystemPasswordChar : passwordChar;
             }
 
             public BaseTextBox()

--- a/MaterialSkinExample/MainForm.Designer.cs
+++ b/MaterialSkinExample/MainForm.Designer.cs
@@ -33,519 +33,539 @@ namespace MaterialSkinExample
         /// </summary>
         private void InitializeComponent()
         {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
-			this.materialFlatButton2 = new MaterialSkin.Controls.MaterialFlatButton();
-			this.materialFlatButton3 = new MaterialSkin.Controls.MaterialFlatButton();
-			this.materialFlatButton1 = new MaterialSkin.Controls.MaterialFlatButton();
-			this.materialDivider1 = new MaterialSkin.Controls.MaterialDivider();
-			this.materialRadioButton4 = new MaterialSkin.Controls.MaterialRadioButton();
-			this.materialLabel1 = new MaterialSkin.Controls.MaterialLabel();
-			this.materialRadioButton3 = new MaterialSkin.Controls.MaterialRadioButton();
-			this.materialRadioButton2 = new MaterialSkin.Controls.MaterialRadioButton();
-			this.materialCheckbox4 = new MaterialSkin.Controls.MaterialCheckBox();
-			this.materialCheckbox3 = new MaterialSkin.Controls.MaterialCheckBox();
-			this.materialCheckbox2 = new MaterialSkin.Controls.MaterialCheckBox();
-			this.materialCheckbox1 = new MaterialSkin.Controls.MaterialCheckBox();
-			this.materialSingleLineTextField2 = new MaterialSkin.Controls.MaterialSingleLineTextField();
-			this.materialSingleLineTextField1 = new MaterialSkin.Controls.MaterialSingleLineTextField();
-			this.materialButton1 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.materialRadioButton1 = new MaterialSkin.Controls.MaterialRadioButton();
-			this.materialTabSelector1 = new MaterialSkin.Controls.MaterialTabSelector();
-			this.materialTabControl1 = new MaterialSkin.Controls.MaterialTabControl();
-			this.tabPage1 = new System.Windows.Forms.TabPage();
-			this.materialRaisedButton1 = new MaterialSkin.Controls.MaterialRaisedButton();
-			this.tabPage2 = new System.Windows.Forms.TabPage();
-			this.materialCheckBox6 = new MaterialSkin.Controls.MaterialCheckBox();
-			this.materialCheckBox5 = new MaterialSkin.Controls.MaterialCheckBox();
-			this.tabPage3 = new System.Windows.Forms.TabPage();
-			this.materialContextMenuStrip1 = new MaterialSkin.Controls.MaterialContextMenuStrip();
-			this.item1ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
-			this.subItem1ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
-			this.subItem2ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
-			this.disabledItemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.item2ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.item3ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
-			this.materialTabControl1.SuspendLayout();
-			this.tabPage1.SuspendLayout();
-			this.tabPage2.SuspendLayout();
-			this.tabPage3.SuspendLayout();
-			this.materialContextMenuStrip1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// materialFlatButton2
-			// 
-			this.materialFlatButton2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialFlatButton2.AutoSize = true;
-			this.materialFlatButton2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialFlatButton2.Depth = 0;
-			this.materialFlatButton2.Location = new System.Drawing.Point(580, 346);
-			this.materialFlatButton2.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-			this.materialFlatButton2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialFlatButton2.Name = "materialFlatButton2";
-			this.materialFlatButton2.Primary = false;
-			this.materialFlatButton2.Size = new System.Drawing.Size(91, 36);
-			this.materialFlatButton2.TabIndex = 13;
-			this.materialFlatButton2.Text = "Secondary";
-			this.materialFlatButton2.UseVisualStyleBackColor = true;
-			// 
-			// materialFlatButton3
-			// 
-			this.materialFlatButton3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialFlatButton3.AutoSize = true;
-			this.materialFlatButton3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialFlatButton3.Depth = 0;
-			this.materialFlatButton3.Enabled = false;
-			this.materialFlatButton3.Location = new System.Drawing.Point(497, 346);
-			this.materialFlatButton3.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-			this.materialFlatButton3.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialFlatButton3.Name = "materialFlatButton3";
-			this.materialFlatButton3.Primary = false;
-			this.materialFlatButton3.Size = new System.Drawing.Size(75, 36);
-			this.materialFlatButton3.TabIndex = 19;
-			this.materialFlatButton3.Text = "DISABLED";
-			this.materialFlatButton3.UseVisualStyleBackColor = true;
-			// 
-			// materialFlatButton1
-			// 
-			this.materialFlatButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialFlatButton1.AutoSize = true;
-			this.materialFlatButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.materialFlatButton1.Depth = 0;
-			this.materialFlatButton1.Location = new System.Drawing.Point(679, 346);
-			this.materialFlatButton1.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-			this.materialFlatButton1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialFlatButton1.Name = "materialFlatButton1";
-			this.materialFlatButton1.Primary = true;
-			this.materialFlatButton1.Size = new System.Drawing.Size(71, 36);
-			this.materialFlatButton1.TabIndex = 1;
-			this.materialFlatButton1.Text = "Primary";
-			this.materialFlatButton1.UseVisualStyleBackColor = true;
-			// 
-			// materialDivider1
-			// 
-			this.materialDivider1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+            this.materialFlatButton2 = new MaterialSkin.Controls.MaterialFlatButton();
+            this.materialFlatButton3 = new MaterialSkin.Controls.MaterialFlatButton();
+            this.materialFlatButton1 = new MaterialSkin.Controls.MaterialFlatButton();
+            this.materialDivider1 = new MaterialSkin.Controls.MaterialDivider();
+            this.materialRadioButton4 = new MaterialSkin.Controls.MaterialRadioButton();
+            this.materialLabel1 = new MaterialSkin.Controls.MaterialLabel();
+            this.materialRadioButton3 = new MaterialSkin.Controls.MaterialRadioButton();
+            this.materialRadioButton2 = new MaterialSkin.Controls.MaterialRadioButton();
+            this.materialCheckbox4 = new MaterialSkin.Controls.MaterialCheckBox();
+            this.materialCheckbox3 = new MaterialSkin.Controls.MaterialCheckBox();
+            this.materialCheckbox2 = new MaterialSkin.Controls.MaterialCheckBox();
+            this.materialCheckbox1 = new MaterialSkin.Controls.MaterialCheckBox();
+            this.materialSingleLineTextField2 = new MaterialSkin.Controls.MaterialSingleLineTextField();
+            this.materialSingleLineTextField1 = new MaterialSkin.Controls.MaterialSingleLineTextField();
+            this.materialButton1 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.materialRadioButton1 = new MaterialSkin.Controls.MaterialRadioButton();
+            this.materialTabSelector1 = new MaterialSkin.Controls.MaterialTabSelector();
+            this.materialTabControl1 = new MaterialSkin.Controls.MaterialTabControl();
+            this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.materialSingleLineTextField3 = new MaterialSkin.Controls.MaterialSingleLineTextField();
+            this.materialRaisedButton1 = new MaterialSkin.Controls.MaterialRaisedButton();
+            this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.materialCheckBox6 = new MaterialSkin.Controls.MaterialCheckBox();
+            this.materialCheckBox5 = new MaterialSkin.Controls.MaterialCheckBox();
+            this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.materialContextMenuStrip1 = new MaterialSkin.Controls.MaterialContextMenuStrip();
+            this.item1ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
+            this.subItem1ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
+            this.subItem2ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
+            this.disabledItemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.item2ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.item3ToolStripMenuItem = new MaterialSkin.Controls.MaterialToolStripMenuItem();
+            this.materialTabControl1.SuspendLayout();
+            this.tabPage1.SuspendLayout();
+            this.tabPage2.SuspendLayout();
+            this.tabPage3.SuspendLayout();
+            this.materialContextMenuStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // materialFlatButton2
+            // 
+            this.materialFlatButton2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialFlatButton2.AutoSize = true;
+            this.materialFlatButton2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialFlatButton2.Depth = 0;
+            this.materialFlatButton2.Location = new System.Drawing.Point(580, 386);
+            this.materialFlatButton2.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.materialFlatButton2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialFlatButton2.Name = "materialFlatButton2";
+            this.materialFlatButton2.Primary = false;
+            this.materialFlatButton2.Size = new System.Drawing.Size(91, 36);
+            this.materialFlatButton2.TabIndex = 13;
+            this.materialFlatButton2.Text = "Secondary";
+            this.materialFlatButton2.UseVisualStyleBackColor = true;
+            // 
+            // materialFlatButton3
+            // 
+            this.materialFlatButton3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialFlatButton3.AutoSize = true;
+            this.materialFlatButton3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialFlatButton3.Depth = 0;
+            this.materialFlatButton3.Enabled = false;
+            this.materialFlatButton3.Location = new System.Drawing.Point(497, 386);
+            this.materialFlatButton3.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.materialFlatButton3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialFlatButton3.Name = "materialFlatButton3";
+            this.materialFlatButton3.Primary = false;
+            this.materialFlatButton3.Size = new System.Drawing.Size(75, 36);
+            this.materialFlatButton3.TabIndex = 19;
+            this.materialFlatButton3.Text = "DISABLED";
+            this.materialFlatButton3.UseVisualStyleBackColor = true;
+            // 
+            // materialFlatButton1
+            // 
+            this.materialFlatButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialFlatButton1.AutoSize = true;
+            this.materialFlatButton1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.materialFlatButton1.Depth = 0;
+            this.materialFlatButton1.Location = new System.Drawing.Point(679, 386);
+            this.materialFlatButton1.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.materialFlatButton1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialFlatButton1.Name = "materialFlatButton1";
+            this.materialFlatButton1.Primary = true;
+            this.materialFlatButton1.Size = new System.Drawing.Size(71, 36);
+            this.materialFlatButton1.TabIndex = 1;
+            this.materialFlatButton1.Text = "Primary";
+            this.materialFlatButton1.UseVisualStyleBackColor = true;
+            // 
+            // materialDivider1
+            // 
+            this.materialDivider1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialDivider1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialDivider1.Depth = 0;
-			this.materialDivider1.Location = new System.Drawing.Point(0, 339);
-			this.materialDivider1.Margin = new System.Windows.Forms.Padding(0);
-			this.materialDivider1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialDivider1.Name = "materialDivider1";
-			this.materialDivider1.Size = new System.Drawing.Size(781, 1);
-			this.materialDivider1.TabIndex = 16;
-			this.materialDivider1.Text = "materialDivider1";
-			// 
-			// materialRadioButton4
-			// 
-			this.materialRadioButton4.AutoSize = true;
-			this.materialRadioButton4.Checked = true;
-			this.materialRadioButton4.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialRadioButton4.Depth = 0;
-			this.materialRadioButton4.Enabled = false;
-			this.materialRadioButton4.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialRadioButton4.Location = new System.Drawing.Point(0, 98);
-			this.materialRadioButton4.Margin = new System.Windows.Forms.Padding(0);
-			this.materialRadioButton4.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialRadioButton4.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRadioButton4.Name = "materialRadioButton4";
-			this.materialRadioButton4.Ripple = true;
-			this.materialRadioButton4.Size = new System.Drawing.Size(163, 30);
-			this.materialRadioButton4.TabIndex = 15;
-			this.materialRadioButton4.TabStop = true;
-			this.materialRadioButton4.Text = "materialRadioButton4";
-			this.materialRadioButton4.UseVisualStyleBackColor = true;
-			// 
-			// materialLabel1
-			// 
-			this.materialLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialDivider1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialDivider1.Depth = 0;
+            this.materialDivider1.Location = new System.Drawing.Point(0, 379);
+            this.materialDivider1.Margin = new System.Windows.Forms.Padding(0);
+            this.materialDivider1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialDivider1.Name = "materialDivider1";
+            this.materialDivider1.Size = new System.Drawing.Size(781, 1);
+            this.materialDivider1.TabIndex = 16;
+            this.materialDivider1.Text = "materialDivider1";
+            // 
+            // materialRadioButton4
+            // 
+            this.materialRadioButton4.AutoSize = true;
+            this.materialRadioButton4.Checked = true;
+            this.materialRadioButton4.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialRadioButton4.Depth = 0;
+            this.materialRadioButton4.Enabled = false;
+            this.materialRadioButton4.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialRadioButton4.Location = new System.Drawing.Point(0, 98);
+            this.materialRadioButton4.Margin = new System.Windows.Forms.Padding(0);
+            this.materialRadioButton4.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialRadioButton4.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRadioButton4.Name = "materialRadioButton4";
+            this.materialRadioButton4.Ripple = true;
+            this.materialRadioButton4.Size = new System.Drawing.Size(163, 30);
+            this.materialRadioButton4.TabIndex = 15;
+            this.materialRadioButton4.TabStop = true;
+            this.materialRadioButton4.Text = "materialRadioButton4";
+            this.materialRadioButton4.UseVisualStyleBackColor = true;
+            // 
+            // materialLabel1
+            // 
+            this.materialLabel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialLabel1.Depth = 0;
-			this.materialLabel1.Font = new System.Drawing.Font("Roboto", 11F);
-			this.materialLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-			this.materialLabel1.Location = new System.Drawing.Point(-4, 77);
-			this.materialLabel1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialLabel1.Name = "materialLabel1";
-			this.materialLabel1.Size = new System.Drawing.Size(736, 64);
-			this.materialLabel1.TabIndex = 14;
-			this.materialLabel1.Text = resources.GetString("materialLabel1.Text");
-			// 
-			// materialRadioButton3
-			// 
-			this.materialRadioButton3.AutoSize = true;
-			this.materialRadioButton3.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialRadioButton3.Depth = 0;
-			this.materialRadioButton3.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialRadioButton3.Location = new System.Drawing.Point(0, 68);
-			this.materialRadioButton3.Margin = new System.Windows.Forms.Padding(0);
-			this.materialRadioButton3.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialRadioButton3.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRadioButton3.Name = "materialRadioButton3";
-			this.materialRadioButton3.Ripple = true;
-			this.materialRadioButton3.Size = new System.Drawing.Size(163, 30);
-			this.materialRadioButton3.TabIndex = 11;
-			this.materialRadioButton3.Text = "materialRadioButton3";
-			this.materialRadioButton3.UseVisualStyleBackColor = true;
-			// 
-			// materialRadioButton2
-			// 
-			this.materialRadioButton2.AutoSize = true;
-			this.materialRadioButton2.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialRadioButton2.Depth = 0;
-			this.materialRadioButton2.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialRadioButton2.Location = new System.Drawing.Point(0, 38);
-			this.materialRadioButton2.Margin = new System.Windows.Forms.Padding(0);
-			this.materialRadioButton2.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialRadioButton2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRadioButton2.Name = "materialRadioButton2";
-			this.materialRadioButton2.Ripple = true;
-			this.materialRadioButton2.Size = new System.Drawing.Size(163, 30);
-			this.materialRadioButton2.TabIndex = 10;
-			this.materialRadioButton2.Text = "materialRadioButton2";
-			this.materialRadioButton2.UseVisualStyleBackColor = true;
-			// 
-			// materialCheckbox4
-			// 
-			this.materialCheckbox4.AutoSize = true;
-			this.materialCheckbox4.Depth = 0;
-			this.materialCheckbox4.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialCheckbox4.Location = new System.Drawing.Point(0, 98);
-			this.materialCheckbox4.Margin = new System.Windows.Forms.Padding(0);
-			this.materialCheckbox4.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialCheckbox4.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialCheckbox4.Name = "materialCheckbox4";
-			this.materialCheckbox4.Ripple = true;
-			this.materialCheckbox4.Size = new System.Drawing.Size(149, 30);
-			this.materialCheckbox4.TabIndex = 7;
-			this.materialCheckbox4.Text = "materialCheckbox4";
-			this.materialCheckbox4.UseVisualStyleBackColor = true;
-			// 
-			// materialCheckbox3
-			// 
-			this.materialCheckbox3.AutoSize = true;
-			this.materialCheckbox3.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialCheckbox3.Depth = 0;
-			this.materialCheckbox3.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialCheckbox3.Location = new System.Drawing.Point(0, 68);
-			this.materialCheckbox3.Margin = new System.Windows.Forms.Padding(0);
-			this.materialCheckbox3.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialCheckbox3.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialCheckbox3.Name = "materialCheckbox3";
-			this.materialCheckbox3.Ripple = true;
-			this.materialCheckbox3.Size = new System.Drawing.Size(149, 30);
-			this.materialCheckbox3.TabIndex = 6;
-			this.materialCheckbox3.Text = "materialCheckbox3";
-			this.materialCheckbox3.UseVisualStyleBackColor = true;
-			// 
-			// materialCheckbox2
-			// 
-			this.materialCheckbox2.AutoSize = true;
-			this.materialCheckbox2.Checked = true;
-			this.materialCheckbox2.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.materialCheckbox2.Depth = 0;
-			this.materialCheckbox2.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialCheckbox2.Location = new System.Drawing.Point(0, 38);
-			this.materialCheckbox2.Margin = new System.Windows.Forms.Padding(0);
-			this.materialCheckbox2.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialCheckbox2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialCheckbox2.Name = "materialCheckbox2";
-			this.materialCheckbox2.Ripple = true;
-			this.materialCheckbox2.Size = new System.Drawing.Size(149, 30);
-			this.materialCheckbox2.TabIndex = 5;
-			this.materialCheckbox2.Text = "materialCheckbox2";
-			this.materialCheckbox2.UseVisualStyleBackColor = true;
-			// 
-			// materialCheckbox1
-			// 
-			this.materialCheckbox1.AutoSize = true;
-			this.materialCheckbox1.Checked = true;
-			this.materialCheckbox1.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.materialCheckbox1.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialCheckbox1.Depth = 0;
-			this.materialCheckbox1.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialCheckbox1.Location = new System.Drawing.Point(0, 8);
-			this.materialCheckbox1.Margin = new System.Windows.Forms.Padding(0);
-			this.materialCheckbox1.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialCheckbox1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialCheckbox1.Name = "materialCheckbox1";
-			this.materialCheckbox1.Ripple = true;
-			this.materialCheckbox1.Size = new System.Drawing.Size(149, 30);
-			this.materialCheckbox1.TabIndex = 4;
-			this.materialCheckbox1.Text = "materialCheckbox1";
-			this.materialCheckbox1.UseVisualStyleBackColor = true;
-			// 
-			// materialSingleLineTextField2
-			// 
-			this.materialSingleLineTextField2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialLabel1.Depth = 0;
+            this.materialLabel1.Font = new System.Drawing.Font("Roboto", 11F);
+            this.materialLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.materialLabel1.Location = new System.Drawing.Point(-4, 117);
+            this.materialLabel1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialLabel1.Name = "materialLabel1";
+            this.materialLabel1.Size = new System.Drawing.Size(736, 64);
+            this.materialLabel1.TabIndex = 14;
+            this.materialLabel1.Text = resources.GetString("materialLabel1.Text");
+            // 
+            // materialRadioButton3
+            // 
+            this.materialRadioButton3.AutoSize = true;
+            this.materialRadioButton3.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialRadioButton3.Depth = 0;
+            this.materialRadioButton3.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialRadioButton3.Location = new System.Drawing.Point(0, 68);
+            this.materialRadioButton3.Margin = new System.Windows.Forms.Padding(0);
+            this.materialRadioButton3.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialRadioButton3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRadioButton3.Name = "materialRadioButton3";
+            this.materialRadioButton3.Ripple = true;
+            this.materialRadioButton3.Size = new System.Drawing.Size(163, 30);
+            this.materialRadioButton3.TabIndex = 11;
+            this.materialRadioButton3.Text = "materialRadioButton3";
+            this.materialRadioButton3.UseVisualStyleBackColor = true;
+            // 
+            // materialRadioButton2
+            // 
+            this.materialRadioButton2.AutoSize = true;
+            this.materialRadioButton2.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialRadioButton2.Depth = 0;
+            this.materialRadioButton2.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialRadioButton2.Location = new System.Drawing.Point(0, 38);
+            this.materialRadioButton2.Margin = new System.Windows.Forms.Padding(0);
+            this.materialRadioButton2.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialRadioButton2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRadioButton2.Name = "materialRadioButton2";
+            this.materialRadioButton2.Ripple = true;
+            this.materialRadioButton2.Size = new System.Drawing.Size(163, 30);
+            this.materialRadioButton2.TabIndex = 10;
+            this.materialRadioButton2.Text = "materialRadioButton2";
+            this.materialRadioButton2.UseVisualStyleBackColor = true;
+            // 
+            // materialCheckbox4
+            // 
+            this.materialCheckbox4.AutoSize = true;
+            this.materialCheckbox4.Depth = 0;
+            this.materialCheckbox4.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckbox4.Location = new System.Drawing.Point(0, 98);
+            this.materialCheckbox4.Margin = new System.Windows.Forms.Padding(0);
+            this.materialCheckbox4.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialCheckbox4.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialCheckbox4.Name = "materialCheckbox4";
+            this.materialCheckbox4.Ripple = true;
+            this.materialCheckbox4.Size = new System.Drawing.Size(149, 30);
+            this.materialCheckbox4.TabIndex = 7;
+            this.materialCheckbox4.Text = "materialCheckbox4";
+            this.materialCheckbox4.UseVisualStyleBackColor = true;
+            // 
+            // materialCheckbox3
+            // 
+            this.materialCheckbox3.AutoSize = true;
+            this.materialCheckbox3.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialCheckbox3.Depth = 0;
+            this.materialCheckbox3.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckbox3.Location = new System.Drawing.Point(0, 68);
+            this.materialCheckbox3.Margin = new System.Windows.Forms.Padding(0);
+            this.materialCheckbox3.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialCheckbox3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialCheckbox3.Name = "materialCheckbox3";
+            this.materialCheckbox3.Ripple = true;
+            this.materialCheckbox3.Size = new System.Drawing.Size(149, 30);
+            this.materialCheckbox3.TabIndex = 6;
+            this.materialCheckbox3.Text = "materialCheckbox3";
+            this.materialCheckbox3.UseVisualStyleBackColor = true;
+            // 
+            // materialCheckbox2
+            // 
+            this.materialCheckbox2.AutoSize = true;
+            this.materialCheckbox2.Checked = true;
+            this.materialCheckbox2.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.materialCheckbox2.Depth = 0;
+            this.materialCheckbox2.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckbox2.Location = new System.Drawing.Point(0, 38);
+            this.materialCheckbox2.Margin = new System.Windows.Forms.Padding(0);
+            this.materialCheckbox2.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialCheckbox2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialCheckbox2.Name = "materialCheckbox2";
+            this.materialCheckbox2.Ripple = true;
+            this.materialCheckbox2.Size = new System.Drawing.Size(149, 30);
+            this.materialCheckbox2.TabIndex = 5;
+            this.materialCheckbox2.Text = "materialCheckbox2";
+            this.materialCheckbox2.UseVisualStyleBackColor = true;
+            // 
+            // materialCheckbox1
+            // 
+            this.materialCheckbox1.AutoSize = true;
+            this.materialCheckbox1.Checked = true;
+            this.materialCheckbox1.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.materialCheckbox1.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialCheckbox1.Depth = 0;
+            this.materialCheckbox1.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckbox1.Location = new System.Drawing.Point(0, 8);
+            this.materialCheckbox1.Margin = new System.Windows.Forms.Padding(0);
+            this.materialCheckbox1.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialCheckbox1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialCheckbox1.Name = "materialCheckbox1";
+            this.materialCheckbox1.Ripple = true;
+            this.materialCheckbox1.Size = new System.Drawing.Size(149, 30);
+            this.materialCheckbox1.TabIndex = 4;
+            this.materialCheckbox1.Text = "materialCheckbox1";
+            this.materialCheckbox1.UseVisualStyleBackColor = true;
+            // 
+            // materialSingleLineTextField2
+            // 
+            this.materialSingleLineTextField2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialSingleLineTextField2.Depth = 0;
-			this.materialSingleLineTextField2.Hint = "Another example hint";
-			this.materialSingleLineTextField2.Location = new System.Drawing.Point(0, 51);
-			this.materialSingleLineTextField2.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialSingleLineTextField2.Name = "materialSingleLineTextField2";
-			this.materialSingleLineTextField2.Size = new System.Drawing.Size(732, 23);
-			this.materialSingleLineTextField2.TabIndex = 3;
-			// 
-			// materialSingleLineTextField1
-			// 
-			this.materialSingleLineTextField1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialSingleLineTextField2.Depth = 0;
+            this.materialSingleLineTextField2.Hint = "Another example hint";
+            this.materialSingleLineTextField2.Location = new System.Drawing.Point(0, 51);
+            this.materialSingleLineTextField2.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialSingleLineTextField2.Name = "materialSingleLineTextField2";
+            this.materialSingleLineTextField2.PasswordChar = '\0';
+            this.materialSingleLineTextField2.Size = new System.Drawing.Size(732, 23);
+            this.materialSingleLineTextField2.TabIndex = 3;
+            this.materialSingleLineTextField2.UseSystemPasswordChar = false;
+            // 
+            // materialSingleLineTextField1
+            // 
+            this.materialSingleLineTextField1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialSingleLineTextField1.Depth = 0;
-			this.materialSingleLineTextField1.Hint = "This is a hint";
-			this.materialSingleLineTextField1.Location = new System.Drawing.Point(0, 14);
-			this.materialSingleLineTextField1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialSingleLineTextField1.Name = "materialSingleLineTextField1";
-			this.materialSingleLineTextField1.Size = new System.Drawing.Size(732, 23);
-			this.materialSingleLineTextField1.TabIndex = 2;
-			// 
-			// materialButton1
-			// 
-			this.materialButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialButton1.Depth = 0;
-			this.materialButton1.Location = new System.Drawing.Point(412, 147);
-			this.materialButton1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialButton1.Name = "materialButton1";
-			this.materialButton1.Primary = true;
-			this.materialButton1.Size = new System.Drawing.Size(135, 36);
-			this.materialButton1.TabIndex = 0;
-			this.materialButton1.Text = "Change Theme";
-			this.materialButton1.UseVisualStyleBackColor = true;
-			this.materialButton1.Click += new System.EventHandler(this.materialButton1_Click);
-			// 
-			// materialRadioButton1
-			// 
-			this.materialRadioButton1.AutoSize = true;
-			this.materialRadioButton1.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialRadioButton1.Depth = 0;
-			this.materialRadioButton1.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialRadioButton1.Location = new System.Drawing.Point(0, 8);
-			this.materialRadioButton1.Margin = new System.Windows.Forms.Padding(0);
-			this.materialRadioButton1.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialRadioButton1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRadioButton1.Name = "materialRadioButton1";
-			this.materialRadioButton1.Ripple = true;
-			this.materialRadioButton1.Size = new System.Drawing.Size(163, 30);
-			this.materialRadioButton1.TabIndex = 9;
-			this.materialRadioButton1.Text = "materialRadioButton1";
-			this.materialRadioButton1.UseVisualStyleBackColor = true;
-			// 
-			// materialTabSelector1
-			// 
-			this.materialTabSelector1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.materialSingleLineTextField1.Depth = 0;
+            this.materialSingleLineTextField1.Hint = "This is a hint";
+            this.materialSingleLineTextField1.Location = new System.Drawing.Point(0, 14);
+            this.materialSingleLineTextField1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialSingleLineTextField1.Name = "materialSingleLineTextField1";
+            this.materialSingleLineTextField1.PasswordChar = '\0';
+            this.materialSingleLineTextField1.Size = new System.Drawing.Size(732, 23);
+            this.materialSingleLineTextField1.TabIndex = 2;
+            this.materialSingleLineTextField1.UseSystemPasswordChar = false;
+            // 
+            // materialButton1
+            // 
+            this.materialButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialButton1.Depth = 0;
+            this.materialButton1.Location = new System.Drawing.Point(412, 187);
+            this.materialButton1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialButton1.Name = "materialButton1";
+            this.materialButton1.Primary = true;
+            this.materialButton1.Size = new System.Drawing.Size(135, 36);
+            this.materialButton1.TabIndex = 0;
+            this.materialButton1.Text = "Change Theme";
+            this.materialButton1.UseVisualStyleBackColor = true;
+            this.materialButton1.Click += new System.EventHandler(this.materialButton1_Click);
+            // 
+            // materialRadioButton1
+            // 
+            this.materialRadioButton1.AutoSize = true;
+            this.materialRadioButton1.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialRadioButton1.Depth = 0;
+            this.materialRadioButton1.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialRadioButton1.Location = new System.Drawing.Point(0, 8);
+            this.materialRadioButton1.Margin = new System.Windows.Forms.Padding(0);
+            this.materialRadioButton1.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialRadioButton1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRadioButton1.Name = "materialRadioButton1";
+            this.materialRadioButton1.Ripple = true;
+            this.materialRadioButton1.Size = new System.Drawing.Size(163, 30);
+            this.materialRadioButton1.TabIndex = 9;
+            this.materialRadioButton1.Text = "materialRadioButton1";
+            this.materialRadioButton1.UseVisualStyleBackColor = true;
+            // 
+            // materialTabSelector1
+            // 
+            this.materialTabSelector1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialTabSelector1.BaseTabControl = this.materialTabControl1;
-			this.materialTabSelector1.Depth = 0;
-			this.materialTabSelector1.Location = new System.Drawing.Point(0, 64);
-			this.materialTabSelector1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialTabSelector1.Name = "materialTabSelector1";
-			this.materialTabSelector1.Size = new System.Drawing.Size(781, 48);
-			this.materialTabSelector1.TabIndex = 17;
-			this.materialTabSelector1.Text = "materialTabSelector1";
-			// 
-			// materialTabControl1
-			// 
-			this.materialTabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.materialTabSelector1.BaseTabControl = this.materialTabControl1;
+            this.materialTabSelector1.Depth = 0;
+            this.materialTabSelector1.Location = new System.Drawing.Point(0, 64);
+            this.materialTabSelector1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialTabSelector1.Name = "materialTabSelector1";
+            this.materialTabSelector1.Size = new System.Drawing.Size(781, 48);
+            this.materialTabSelector1.TabIndex = 17;
+            this.materialTabSelector1.Text = "materialTabSelector1";
+            // 
+            // materialTabControl1
+            // 
+            this.materialTabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialTabControl1.Controls.Add(this.tabPage1);
-			this.materialTabControl1.Controls.Add(this.tabPage2);
-			this.materialTabControl1.Controls.Add(this.tabPage3);
-			this.materialTabControl1.Depth = 0;
-			this.materialTabControl1.Location = new System.Drawing.Point(14, 111);
-			this.materialTabControl1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialTabControl1.Name = "materialTabControl1";
-			this.materialTabControl1.SelectedIndex = 0;
-			this.materialTabControl1.Size = new System.Drawing.Size(740, 216);
-			this.materialTabControl1.TabIndex = 18;
-			// 
-			// tabPage1
-			// 
-			this.tabPage1.BackColor = System.Drawing.Color.White;
-			this.tabPage1.Controls.Add(this.materialRaisedButton1);
-			this.tabPage1.Controls.Add(this.materialSingleLineTextField1);
-			this.tabPage1.Controls.Add(this.materialSingleLineTextField2);
-			this.tabPage1.Controls.Add(this.materialButton1);
-			this.tabPage1.Controls.Add(this.materialLabel1);
-			this.tabPage1.Location = new System.Drawing.Point(4, 22);
-			this.tabPage1.Name = "tabPage1";
-			this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPage1.Size = new System.Drawing.Size(732, 190);
-			this.tabPage1.TabIndex = 0;
-			this.tabPage1.Text = "tabPage1";
-			// 
-			// materialRaisedButton1
-			// 
-			this.materialRaisedButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.materialRaisedButton1.Depth = 0;
-			this.materialRaisedButton1.Location = new System.Drawing.Point(553, 147);
-			this.materialRaisedButton1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialRaisedButton1.Name = "materialRaisedButton1";
-			this.materialRaisedButton1.Primary = true;
-			this.materialRaisedButton1.Size = new System.Drawing.Size(179, 36);
-			this.materialRaisedButton1.TabIndex = 21;
-			this.materialRaisedButton1.Text = "Change color scheme";
-			this.materialRaisedButton1.UseVisualStyleBackColor = true;
-			this.materialRaisedButton1.Click += new System.EventHandler(this.materialRaisedButton1_Click);
-			// 
-			// tabPage2
-			// 
-			this.tabPage2.BackColor = System.Drawing.Color.White;
-			this.tabPage2.Controls.Add(this.materialCheckBox6);
-			this.tabPage2.Controls.Add(this.materialCheckBox5);
-			this.tabPage2.Controls.Add(this.materialCheckbox3);
-			this.tabPage2.Controls.Add(this.materialCheckbox1);
-			this.tabPage2.Controls.Add(this.materialCheckbox2);
-			this.tabPage2.Controls.Add(this.materialCheckbox4);
-			this.tabPage2.Location = new System.Drawing.Point(4, 22);
-			this.tabPage2.Name = "tabPage2";
-			this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPage2.Size = new System.Drawing.Size(732, 190);
-			this.tabPage2.TabIndex = 1;
-			this.tabPage2.Text = "tabPage2";
-			// 
-			// materialCheckBox6
-			// 
-			this.materialCheckBox6.AutoSize = true;
-			this.materialCheckBox6.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialCheckBox6.Depth = 0;
-			this.materialCheckBox6.Enabled = false;
-			this.materialCheckBox6.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialCheckBox6.Location = new System.Drawing.Point(0, 158);
-			this.materialCheckBox6.Margin = new System.Windows.Forms.Padding(0);
-			this.materialCheckBox6.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialCheckBox6.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialCheckBox6.Name = "materialCheckBox6";
-			this.materialCheckBox6.Ripple = true;
-			this.materialCheckBox6.Size = new System.Drawing.Size(150, 30);
-			this.materialCheckBox6.TabIndex = 9;
-			this.materialCheckBox6.Text = "materialCheckBox6";
-			this.materialCheckBox6.UseVisualStyleBackColor = true;
-			// 
-			// materialCheckBox5
-			// 
-			this.materialCheckBox5.AutoSize = true;
-			this.materialCheckBox5.Checked = true;
-			this.materialCheckBox5.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.materialCheckBox5.Cursor = System.Windows.Forms.Cursors.Default;
-			this.materialCheckBox5.Depth = 0;
-			this.materialCheckBox5.Enabled = false;
-			this.materialCheckBox5.Font = new System.Drawing.Font("Roboto", 10F);
-			this.materialCheckBox5.Location = new System.Drawing.Point(0, 128);
-			this.materialCheckBox5.Margin = new System.Windows.Forms.Padding(0);
-			this.materialCheckBox5.MouseLocation = new System.Drawing.Point(-1, -1);
-			this.materialCheckBox5.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialCheckBox5.Name = "materialCheckBox5";
-			this.materialCheckBox5.Ripple = true;
-			this.materialCheckBox5.Size = new System.Drawing.Size(150, 30);
-			this.materialCheckBox5.TabIndex = 8;
-			this.materialCheckBox5.Text = "materialCheckBox5";
-			this.materialCheckBox5.UseVisualStyleBackColor = true;
-			// 
-			// tabPage3
-			// 
-			this.tabPage3.BackColor = System.Drawing.Color.White;
-			this.tabPage3.Controls.Add(this.materialRadioButton4);
-			this.tabPage3.Controls.Add(this.materialRadioButton1);
-			this.tabPage3.Controls.Add(this.materialRadioButton2);
-			this.tabPage3.Controls.Add(this.materialRadioButton3);
-			this.tabPage3.Location = new System.Drawing.Point(4, 22);
-			this.tabPage3.Name = "tabPage3";
-			this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-			this.tabPage3.Size = new System.Drawing.Size(732, 190);
-			this.tabPage3.TabIndex = 2;
-			this.tabPage3.Text = "MaterialTabPage3";
-			// 
-			// materialContextMenuStrip1
-			// 
-			this.materialContextMenuStrip1.BackColor = System.Drawing.Color.White;
-			this.materialContextMenuStrip1.Depth = 0;
-			this.materialContextMenuStrip1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
-			this.materialContextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.materialTabControl1.Controls.Add(this.tabPage1);
+            this.materialTabControl1.Controls.Add(this.tabPage2);
+            this.materialTabControl1.Controls.Add(this.tabPage3);
+            this.materialTabControl1.Depth = 0;
+            this.materialTabControl1.Location = new System.Drawing.Point(14, 111);
+            this.materialTabControl1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialTabControl1.Name = "materialTabControl1";
+            this.materialTabControl1.SelectedIndex = 0;
+            this.materialTabControl1.Size = new System.Drawing.Size(740, 256);
+            this.materialTabControl1.TabIndex = 18;
+            // 
+            // tabPage1
+            // 
+            this.tabPage1.BackColor = System.Drawing.Color.White;
+            this.tabPage1.Controls.Add(this.materialSingleLineTextField3);
+            this.tabPage1.Controls.Add(this.materialRaisedButton1);
+            this.tabPage1.Controls.Add(this.materialSingleLineTextField1);
+            this.tabPage1.Controls.Add(this.materialSingleLineTextField2);
+            this.tabPage1.Controls.Add(this.materialButton1);
+            this.tabPage1.Controls.Add(this.materialLabel1);
+            this.tabPage1.Location = new System.Drawing.Point(4, 22);
+            this.tabPage1.Name = "tabPage1";
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage1.Size = new System.Drawing.Size(732, 230);
+            this.tabPage1.TabIndex = 0;
+            this.tabPage1.Text = "tabPage1";
+            // 
+            // materialSingleLineTextField3
+            // 
+            this.materialSingleLineTextField3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialSingleLineTextField3.Depth = 0;
+            this.materialSingleLineTextField3.Hint = "This is a password";
+            this.materialSingleLineTextField3.Location = new System.Drawing.Point(0, 88);
+            this.materialSingleLineTextField3.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialSingleLineTextField3.Name = "materialSingleLineTextField3";
+            this.materialSingleLineTextField3.PasswordChar = '\0';
+            this.materialSingleLineTextField3.Size = new System.Drawing.Size(732, 23);
+            this.materialSingleLineTextField3.TabIndex = 22;
+            this.materialSingleLineTextField3.UseSystemPasswordChar = true;
+            // 
+            // materialRaisedButton1
+            // 
+            this.materialRaisedButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.materialRaisedButton1.Depth = 0;
+            this.materialRaisedButton1.Location = new System.Drawing.Point(553, 187);
+            this.materialRaisedButton1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialRaisedButton1.Name = "materialRaisedButton1";
+            this.materialRaisedButton1.Primary = true;
+            this.materialRaisedButton1.Size = new System.Drawing.Size(179, 36);
+            this.materialRaisedButton1.TabIndex = 21;
+            this.materialRaisedButton1.Text = "Change color scheme";
+            this.materialRaisedButton1.UseVisualStyleBackColor = true;
+            this.materialRaisedButton1.Click += new System.EventHandler(this.materialRaisedButton1_Click);
+            // 
+            // tabPage2
+            // 
+            this.tabPage2.BackColor = System.Drawing.Color.White;
+            this.tabPage2.Controls.Add(this.materialCheckBox6);
+            this.tabPage2.Controls.Add(this.materialCheckBox5);
+            this.tabPage2.Controls.Add(this.materialCheckbox3);
+            this.tabPage2.Controls.Add(this.materialCheckbox1);
+            this.tabPage2.Controls.Add(this.materialCheckbox2);
+            this.tabPage2.Controls.Add(this.materialCheckbox4);
+            this.tabPage2.Location = new System.Drawing.Point(4, 22);
+            this.tabPage2.Name = "tabPage2";
+            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage2.Size = new System.Drawing.Size(732, 250);
+            this.tabPage2.TabIndex = 1;
+            this.tabPage2.Text = "tabPage2";
+            // 
+            // materialCheckBox6
+            // 
+            this.materialCheckBox6.AutoSize = true;
+            this.materialCheckBox6.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialCheckBox6.Depth = 0;
+            this.materialCheckBox6.Enabled = false;
+            this.materialCheckBox6.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckBox6.Location = new System.Drawing.Point(0, 158);
+            this.materialCheckBox6.Margin = new System.Windows.Forms.Padding(0);
+            this.materialCheckBox6.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialCheckBox6.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialCheckBox6.Name = "materialCheckBox6";
+            this.materialCheckBox6.Ripple = true;
+            this.materialCheckBox6.Size = new System.Drawing.Size(150, 30);
+            this.materialCheckBox6.TabIndex = 9;
+            this.materialCheckBox6.Text = "materialCheckBox6";
+            this.materialCheckBox6.UseVisualStyleBackColor = true;
+            // 
+            // materialCheckBox5
+            // 
+            this.materialCheckBox5.AutoSize = true;
+            this.materialCheckBox5.Checked = true;
+            this.materialCheckBox5.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.materialCheckBox5.Cursor = System.Windows.Forms.Cursors.Default;
+            this.materialCheckBox5.Depth = 0;
+            this.materialCheckBox5.Enabled = false;
+            this.materialCheckBox5.Font = new System.Drawing.Font("Roboto", 10F);
+            this.materialCheckBox5.Location = new System.Drawing.Point(0, 128);
+            this.materialCheckBox5.Margin = new System.Windows.Forms.Padding(0);
+            this.materialCheckBox5.MouseLocation = new System.Drawing.Point(-1, -1);
+            this.materialCheckBox5.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialCheckBox5.Name = "materialCheckBox5";
+            this.materialCheckBox5.Ripple = true;
+            this.materialCheckBox5.Size = new System.Drawing.Size(150, 30);
+            this.materialCheckBox5.TabIndex = 8;
+            this.materialCheckBox5.Text = "materialCheckBox5";
+            this.materialCheckBox5.UseVisualStyleBackColor = true;
+            // 
+            // tabPage3
+            // 
+            this.tabPage3.BackColor = System.Drawing.Color.White;
+            this.tabPage3.Controls.Add(this.materialRadioButton4);
+            this.tabPage3.Controls.Add(this.materialRadioButton1);
+            this.tabPage3.Controls.Add(this.materialRadioButton2);
+            this.tabPage3.Controls.Add(this.materialRadioButton3);
+            this.tabPage3.Location = new System.Drawing.Point(4, 22);
+            this.tabPage3.Name = "tabPage3";
+            this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPage3.Size = new System.Drawing.Size(732, 250);
+            this.tabPage3.TabIndex = 2;
+            this.tabPage3.Text = "MaterialTabPage3";
+            // 
+            // materialContextMenuStrip1
+            // 
+            this.materialContextMenuStrip1.BackColor = System.Drawing.Color.White;
+            this.materialContextMenuStrip1.Depth = 0;
+            this.materialContextMenuStrip1.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F);
+            this.materialContextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.item1ToolStripMenuItem,
             this.disabledItemToolStripMenuItem,
             this.item2ToolStripMenuItem,
             this.toolStripSeparator1,
             this.item3ToolStripMenuItem});
-			this.materialContextMenuStrip1.Margin = new System.Windows.Forms.Padding(16, 8, 16, 8);
-			this.materialContextMenuStrip1.MouseState = MaterialSkin.MouseState.HOVER;
-			this.materialContextMenuStrip1.Name = "materialContextMenuStrip1";
-			this.materialContextMenuStrip1.Size = new System.Drawing.Size(166, 130);
-			// 
-			// item1ToolStripMenuItem
-			// 
-			this.item1ToolStripMenuItem.AutoSize = false;
-			this.item1ToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.materialContextMenuStrip1.Margin = new System.Windows.Forms.Padding(16, 8, 16, 8);
+            this.materialContextMenuStrip1.MouseState = MaterialSkin.MouseState.HOVER;
+            this.materialContextMenuStrip1.Name = "materialContextMenuStrip1";
+            this.materialContextMenuStrip1.Size = new System.Drawing.Size(166, 130);
+            // 
+            // item1ToolStripMenuItem
+            // 
+            this.item1ToolStripMenuItem.AutoSize = false;
+            this.item1ToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.subItem1ToolStripMenuItem,
             this.subItem2ToolStripMenuItem});
-			this.item1ToolStripMenuItem.Name = "item1ToolStripMenuItem";
-			this.item1ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
-			this.item1ToolStripMenuItem.Text = "Item 1";
-			// 
-			// subItem1ToolStripMenuItem
-			// 
-			this.subItem1ToolStripMenuItem.AutoSize = false;
-			this.subItem1ToolStripMenuItem.Name = "subItem1ToolStripMenuItem";
-			this.subItem1ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
-			this.subItem1ToolStripMenuItem.Text = "SubItem 1";
-			// 
-			// subItem2ToolStripMenuItem
-			// 
-			this.subItem2ToolStripMenuItem.AutoSize = false;
-			this.subItem2ToolStripMenuItem.Name = "subItem2ToolStripMenuItem";
-			this.subItem2ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
-			this.subItem2ToolStripMenuItem.Text = "SubItem 2";
-			// 
-			// disabledItemToolStripMenuItem
-			// 
-			this.disabledItemToolStripMenuItem.AutoSize = false;
-			this.disabledItemToolStripMenuItem.Enabled = false;
-			this.disabledItemToolStripMenuItem.Name = "disabledItemToolStripMenuItem";
-			this.disabledItemToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
-			this.disabledItemToolStripMenuItem.Text = "Disabled item";
-			// 
-			// item2ToolStripMenuItem
-			// 
-			this.item2ToolStripMenuItem.AutoSize = false;
-			this.item2ToolStripMenuItem.Name = "item2ToolStripMenuItem";
-			this.item2ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
-			this.item2ToolStripMenuItem.Text = "Item 2";
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(162, 6);
-			// 
-			// item3ToolStripMenuItem
-			// 
-			this.item3ToolStripMenuItem.AutoSize = false;
-			this.item3ToolStripMenuItem.Name = "item3ToolStripMenuItem";
-			this.item3ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
-			this.item3ToolStripMenuItem.Text = "Item 3";
-			// 
-			// MainForm
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.BackColor = System.Drawing.Color.White;
-			this.ClientSize = new System.Drawing.Size(773, 389);
-			this.ContextMenuStrip = this.materialContextMenuStrip1;
-			this.Controls.Add(this.materialFlatButton3);
-			this.Controls.Add(this.materialFlatButton2);
-			this.Controls.Add(this.materialTabSelector1);
-			this.Controls.Add(this.materialTabControl1);
-			this.Controls.Add(this.materialDivider1);
-			this.Controls.Add(this.materialFlatButton1);
-			this.Name = "MainForm";
-			this.Text = "MaterialSkin Demo";
-			this.materialTabControl1.ResumeLayout(false);
-			this.tabPage1.ResumeLayout(false);
-			this.tabPage2.ResumeLayout(false);
-			this.tabPage2.PerformLayout();
-			this.tabPage3.ResumeLayout(false);
-			this.tabPage3.PerformLayout();
-			this.materialContextMenuStrip1.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.item1ToolStripMenuItem.Name = "item1ToolStripMenuItem";
+            this.item1ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            this.item1ToolStripMenuItem.Text = "Item 1";
+            // 
+            // subItem1ToolStripMenuItem
+            // 
+            this.subItem1ToolStripMenuItem.AutoSize = false;
+            this.subItem1ToolStripMenuItem.Name = "subItem1ToolStripMenuItem";
+            this.subItem1ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
+            this.subItem1ToolStripMenuItem.Text = "SubItem 1";
+            // 
+            // subItem2ToolStripMenuItem
+            // 
+            this.subItem2ToolStripMenuItem.AutoSize = false;
+            this.subItem2ToolStripMenuItem.Name = "subItem2ToolStripMenuItem";
+            this.subItem2ToolStripMenuItem.Size = new System.Drawing.Size(152, 30);
+            this.subItem2ToolStripMenuItem.Text = "SubItem 2";
+            // 
+            // disabledItemToolStripMenuItem
+            // 
+            this.disabledItemToolStripMenuItem.AutoSize = false;
+            this.disabledItemToolStripMenuItem.Enabled = false;
+            this.disabledItemToolStripMenuItem.Name = "disabledItemToolStripMenuItem";
+            this.disabledItemToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            this.disabledItemToolStripMenuItem.Text = "Disabled item";
+            // 
+            // item2ToolStripMenuItem
+            // 
+            this.item2ToolStripMenuItem.AutoSize = false;
+            this.item2ToolStripMenuItem.Name = "item2ToolStripMenuItem";
+            this.item2ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            this.item2ToolStripMenuItem.Text = "Item 2";
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(162, 6);
+            // 
+            // item3ToolStripMenuItem
+            // 
+            this.item3ToolStripMenuItem.AutoSize = false;
+            this.item3ToolStripMenuItem.Name = "item3ToolStripMenuItem";
+            this.item3ToolStripMenuItem.Size = new System.Drawing.Size(170, 30);
+            this.item3ToolStripMenuItem.Text = "Item 3";
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.White;
+            this.ClientSize = new System.Drawing.Size(773, 429);
+            this.ContextMenuStrip = this.materialContextMenuStrip1;
+            this.Controls.Add(this.materialFlatButton3);
+            this.Controls.Add(this.materialFlatButton2);
+            this.Controls.Add(this.materialTabSelector1);
+            this.Controls.Add(this.materialTabControl1);
+            this.Controls.Add(this.materialDivider1);
+            this.Controls.Add(this.materialFlatButton1);
+            this.Name = "MainForm";
+            this.Text = "MaterialSkin Demo";
+            this.materialTabControl1.ResumeLayout(false);
+            this.tabPage1.ResumeLayout(false);
+            this.tabPage2.ResumeLayout(false);
+            this.tabPage2.PerformLayout();
+            this.tabPage3.ResumeLayout(false);
+            this.tabPage3.PerformLayout();
+            this.materialContextMenuStrip1.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -583,5 +603,6 @@ namespace MaterialSkinExample
 		private MaterialCheckBox materialCheckBox6;
 		private MaterialRaisedButton materialRaisedButton1;
 		private MaterialFlatButton materialFlatButton3;
+        private MaterialSingleLineTextField materialSingleLineTextField3;
     }
 }


### PR DESCRIPTION
This change adds the ```UseSystemPasswordChar``` and ```PasswordChar``` property to ```MaterialSingleLineTextField``` - there is a comment for this in #18.

The ```UseSystemPasswordChar``` property on the ```TextBox``` does not support setting a hint using ```SendMessage(Handle, EM_SETCUEBANNER, (int)IntPtr.Zero, Hint)```.
When used the hint never shows, so instead it uses its own logic to determine the default system password char.

The example application has also been updated with a new field using ```UseSystemPasswordChar``` set to true.