### PR TITLE
Exposed more properties/methods on MaterialSingleLineTextField and fixed #43 for the MaterialTabSelector.

### DIFF
--- a/MaterialSkin/Controls/MaterialSingleLineTextField.cs
+++ b/MaterialSkin/Controls/MaterialSingleLineTextField.cs
@@ -16,13 +16,22 @@ namespace MaterialSkin.Controls
         public MaterialSkinManager SkinManager { get { return MaterialSkinManager.Instance; } }
         [Browsable(false)]
         public MouseState MouseState { get; set; }
-        
+
 
         public override string Text { get { return baseTextBox.Text; } set { baseTextBox.Text = value; } }
+        public string SelectedText { get { return baseTextBox.SelectedText; } set { baseTextBox.SelectedText = value; } }
         public string Hint { get { return baseTextBox.Hint; } set { baseTextBox.Hint = value; } }
+
+        public int SelectionStart { get { return baseTextBox.SelectionStart; } set { baseTextBox.SelectionStart = value; } }
+        public int SelectionLength { get { return baseTextBox.SelectionLength; } set { baseTextBox.SelectionLength = value; } }
+        public int TextLength { get { return baseTextBox.TextLength; } }
 
         public bool UseSystemPasswordChar { get { return baseTextBox.UseSystemPasswordChar; } set { baseTextBox.UseSystemPasswordChar = value; } }
         public char PasswordChar { get { return baseTextBox.PasswordChar; } set { baseTextBox.PasswordChar = value; } }
+
+        public void SelectAll() { baseTextBox.SelectAll(); }
+        public void Clear() { baseTextBox.Clear(); }
+
 
         # region Forwarding events to baseTextBox
         public event EventHandler AcceptsTabChanged
@@ -1041,6 +1050,16 @@ namespace MaterialSkin.Controls
                     SetBasePasswordChar();
                 }
             }
+
+            public new void SelectAll()
+            {
+                BeginInvoke((MethodInvoker) delegate()
+                {
+                    base.Focus();
+                    base.SelectAll();
+                });
+            }
+
 
             private char useSystemPasswordChar = EmptyChar;
             public new bool UseSystemPasswordChar

--- a/MaterialSkin/Controls/MaterialTabSelector.cs
+++ b/MaterialSkin/Controls/MaterialTabSelector.cs
@@ -75,7 +75,7 @@ namespace MaterialSkin.Controls
 
             if (baseTabControl == null) return;
 
-            if (!animationManager.IsAnimating() || tabRects == null)
+            if (!animationManager.IsAnimating() || tabRects == null ||  tabRects.Count != baseTabControl.TabCount)
                 UpdateTabRects();
 
             double animationProgress = animationManager.GetProgress();

--- a/MaterialSkin/MaterialSkin.csproj
+++ b/MaterialSkin/MaterialSkin.csproj
@@ -89,6 +89,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Controls\MaterialTabSelector.resx">
+      <DependentUpon>MaterialTabSelector.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
Related to issue #39. The SelectAll() method wasn't accessible on the MaterialSingleLineTextField so I have added this in. 

Added the following properties to the SingleLineTextField:
int SelectionStart
int SelectionLength
int TextLength
string SelectedText

Added the following methods to the SingleLineTextField:
void SelectAll(); 
void Clear();