### PR TITLE
Update MaterialListView.cs

### DIFF
--- a/MaterialSkin/Controls/MaterialListView.cs
+++ b/MaterialSkin/Controls/MaterialListView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
@@ -19,6 +19,8 @@ namespace MaterialSkin.Controls
 		public MouseState MouseState { get; set; }
 		[Browsable(false)]
 		public Point MouseLocation { get; set; }
+        public float fillPercent = 0;
+        public Color highlightColor = Color.Red;
 
 		public MaterialListView()
 		{
@@ -71,10 +73,17 @@ namespace MaterialSkin.Controls
 			var b = new Bitmap(e.Item.Bounds.Width, e.Item.Bounds.Height);
 			var g = Graphics.FromImage(b);
 
-			//Draw the background color of the item
-			g.FillRectangle(new SolidBrush(e.Item.BackColor), new Rectangle(new Point(e.Bounds.X, 0), e.Bounds.Size));
-			
-			if (e.State.HasFlag(ListViewItemStates.Selected))
+            //always draw default background
+            int divideSpot = (int)((fillPercent * e.Bounds.Size.Width) / 100);      //The spot where the progress splits into background color
+
+            Rectangle firstRect = e.Bounds;     //Set the rectnagle of where
+            firstRect.Width = divideSpot;       //the progress is drawn
+
+            g.FillRectangle(new SolidBrush(e.Item.BackColor), new Rectangle(new Point(e.Bounds.X, 0), e.Bounds.Size));      //Draw the item's normal background
+            g.FillRectangle(new SolidBrush(highlightColor), new Rectangle(new Point(e.Bounds.X, 0), firstRect.Size));       //Fill with highlight
+            
+
+            if (e.State.HasFlag(ListViewItemStates.Selected))
 			{
 				//selected background
 				g.FillRectangle(SkinManager.GetFlatButtonPressedBackgroundBrush(), new Rectangle(new Point(e.Bounds.X, 0), e.Bounds.Size));

--- a/MaterialSkin/Controls/MaterialListView.cs
+++ b/MaterialSkin/Controls/MaterialListView.cs
@@ -71,8 +71,8 @@ namespace MaterialSkin.Controls
 			var b = new Bitmap(e.Item.Bounds.Width, e.Item.Bounds.Height);
 			var g = Graphics.FromImage(b);
 
-			//always draw default background
-			g.FillRectangle(new SolidBrush(SkinManager.GetApplicationBackgroundColor()), new Rectangle(new Point(e.Bounds.X, 0), e.Bounds.Size));
+			//Draw the background color of the item
+			g.FillRectangle(new SolidBrush(e.Item.BackColor), new Rectangle(new Point(e.Bounds.X, 0), e.Bounds.Size));
 			
 			if (e.State.HasFlag(ListViewItemStates.Selected))
 			{


### PR DESCRIPTION
Changed line 75 to draw the item's back color instead of the form's backcolor.
Should still have the form's backcolor on new items, but if we want to highlight something in the list now we can.