### PR TITLE
Scale Action Bar and Status Bar height based on dpi.

### DIFF
--- a/MaterialSkin/Controls/MaterialForm.cs
+++ b/MaterialSkin/Controls/MaterialForm.cs
@@ -78,9 +78,9 @@ namespace MaterialSkin.Controls
             {HTBOTTOMRIGHT, WMSZ_BOTTOMRIGHT}
         };
 
-        private const int STATUS_BAR_BUTTON_WIDTH = STATUS_BAR_HEIGHT;
-        private const int STATUS_BAR_HEIGHT = 24;
-        private const int ACTION_BAR_HEIGHT = 40;
+        private readonly int STATUS_BAR_BUTTON_WIDTH;
+        private readonly int STATUS_BAR_HEIGHT;
+        private readonly int ACTION_BAR_HEIGHT;
 
         private const uint TPM_LEFTALIGN = 0x0000;
         private const uint TPM_RETURNCMD = 0x0100;
@@ -161,6 +161,14 @@ namespace MaterialSkin.Controls
             Sizable = true;
             DoubleBuffered = true;
             SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.ResizeRedraw, true);
+            float scale;
+            using (Graphics g = this.CreateGraphics())
+            {
+                scale = g.DpiY / 96.0f;
+            }
+            ACTION_BAR_HEIGHT = (int)(40 * scale);
+            STATUS_BAR_HEIGHT = (int)(24 * scale);
+            STATUS_BAR_BUTTON_WIDTH = STATUS_BAR_HEIGHT;
 
             // This enables the form to trigger the MouseMove event even when mouse is over another control
             Application.AddMessageFilter(new MouseMessageFilter());


### PR DESCRIPTION
On higher dpi settings, the size of the action bar and status bar decreases.
This scales them so that they will remain the same size regardless of the dpi setting.

96 dpi (100%):
![96 dpi (100%)](https://user-images.githubusercontent.com/12672701/29742816-a40b6476-8a8e-11e7-9047-13a1cf0840e9.png)


144 dpi (150%) (before PR):
As you can see the size of the action and status bars has decreased leaving the white space in its place.
![144 dpi (150%) (before PR)](https://user-images.githubusercontent.com/12672701/29742818-a80ad5fc-8a8e-11e7-81f0-6ae5020fb583.png)


144 dpi (150%) (after PR):
This is how it looks after this commit. The status and action bars are now the same size as they were on 96dpi (100%).
![144 dpi (150%) (after PR)](https://user-images.githubusercontent.com/12672701/29742821-ad72eb74-8a8e-11e7-947f-efb485848369.png)

